### PR TITLE
Get rid off upstream2downstream subqueue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,6 @@ repos:
     - id: flake8
       args:
         - --max-line-length=100
-        - --per-file-ignores=files/packit.wsgi:F401,E402
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.711
     hooks:

--- a/files/bin/run.sh
+++ b/files/bin/run.sh
@@ -45,4 +45,4 @@ export GIT_SSH_COMMAND="ssh -i ${HOME}/.ssh/id_rsa  -F ${HOME}/ssh_config"
 export LC_ALL="C"
 # This part can be used for LOCAL TESTING
 # exec python3 /home/betka/tasks.py
-exec celery worker -A tasks -Q queue.betka --loglevel=debug --concurrency=1
+exec celery worker -A tasks -Q queue.betka-fedora --loglevel=debug --concurrency=1

--- a/files/home/tasks.py
+++ b/files/home/tasks.py
@@ -3,15 +3,15 @@ from frambo.celery_app import app
 from betka.core import Betka
 
 
-@app.task(name="task.betka.upstream2downstream.master_sync")
+@app.task(name="task.betka.master_sync")
 def master_sync(message):
-    betka = Betka(task_name="task.betka.upstream2downstream.master_sync")
+    betka = Betka(task_name="task.betka.master_sync")
     if betka.get_master_fedmsg_info(message) and betka.prepare():
         betka.run_sync()
 
 
-@app.task(name="task.betka.upstream2downstream.pr_sync")
+@app.task(name="task.betka.pr_sync")
 def pr_sync(message):
-    betka = Betka(task_name="task.betka.upstream2downstream.pr_sync")
+    betka = Betka(task_name="task.betka.pr_sync")
     if betka.get_pr_fedmsg_info(message) and betka.prepare():
         betka.run_sync()

--- a/upstream_master_sync.py
+++ b/upstream_master_sync.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     # Define which tasks go to which queue
     app.conf.update(
         task_routes={
-            "task.betka.upstream2downstream.master_sync": {"queue": "queue.betka"}
+            "task.betka.master_sync": {"queue": "queue.betka-fedora"}
         }
     )
     message = {
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     }
 
     result1 = app.send_task(
-        name="task.betka.upstream2downstream.master_sync", kwargs={"message": message}
+        name="task.betka.master_sync", kwargs={"message": message}
     )
 
     # Give Celery some time to pick up the message from queue and run the task


### PR DESCRIPTION
`upstreasm2downstream` subqueue does not make sense.
Get rid off them.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>