### PR TITLE
Fix issue when PR is valid but no for correct branch

### DIFF
--- a/betka/core.py
+++ b/betka/core.py
@@ -315,14 +315,16 @@ class Betka(Bot):
         description_msg = COMMIT_MASTER_MSG.format(
             hash=self.upstream_hash, repo=self.repo
         )
-        pr_id = self.pagure_api.check_downstream_pull_requests(commit_msg)
+        pr_id = self.pagure_api.check_downstream_pull_requests(
+            msg_to_check=commit_msg,
+            branch=branch
+        )
         if not pr_id:
             Git.sync_fork_with_origin(self.pagure_api.full_downstream_url, branch)
 
         if not self.sync_upstream_to_downstream_directory():
             return False
-        self.info(os.getcwd())
-        self.info(str(self.downstream_dir))
+
         # git {add,commit,push} all files in local dist-git repo
         Git.git_add_all(self.upstream_message, description_msg)
         # Prepare betka_schema used for sending mail and Pagure Pull Request

--- a/betka/pagure.py
+++ b/betka/pagure.py
@@ -99,7 +99,7 @@ class PagureAPI(object):
             raise
 
     def check_downstream_pull_requests(
-        self, msg_to_check: str, check_user: bool = True
+        self, msg_to_check: str, branch: str, check_user: bool = True
     ):
         """
         Checks if downstream already contains pull request. Check is based in the msg_to_check
@@ -124,6 +124,9 @@ class PagureAPI(object):
                     user,
                     pr_id,
                 )
+                # Check if the PR is for correct branch
+                if out["branch"] != branch:
+                    continue
                 if check_user and out["user"]["name"] == user:
                     return pr_id
                 else:

--- a/tests/unit/test_pagure.py
+++ b/tests/unit/test_pagure.py
@@ -92,32 +92,41 @@ class TestBetkaPagure(object):
         assert self.pa._get_branches() == expected
 
     @pytest.mark.parametrize(
-        "json_file,msg,check_user,return_code",
+        "json_file,msg,branch,check_user,return_code",
         [
             (
-                no_pullrequest(), "", False,
+                no_pullrequest(), "", "f30", False,
                 None,
             ),
             (
-                one_pullrequest(), "abc", False,
+                one_pullrequest(), "abc", "f30", False,
                 None,
             ),
             (
-                one_pullrequest(), "Update from the upstream", False,
+                one_pullrequest(), "abc", "f28", False,
+                None,
+            ),
+            (
+                one_pullrequest(), "Update from the upstream", "f30", False,
+                None,
+            ),
+            (
+                one_pullrequest(), "Update from the upstream", "f28", False,
                 5,
             ),
             (
-                one_pullrequest(), "Update from the upstream", True,
+                one_pullrequest(), "Update from the upstream", "f28", True,
                 5,
             )
         ]
     )
-    def test_downstream_pull_requests(self, json_file, msg, check_user, return_code):
+    def test_downstream_pull_requests(self, json_file, msg, branch, check_user, return_code):
         flexmock(self.pa)\
             .should_receive("get_status_and_dict_from_request")\
             .with_args(url="https://src.fedoraproject.org/api/0/container/foobar/pull-requests")\
             .and_return(200, json_file)
         assert self.pa.check_downstream_pull_requests(
             msg_to_check=msg,
+            branch=branch,
             check_user=check_user
         ) == return_code


### PR DESCRIPTION
Betka don't create a new PR for a branch in case PR exists
for another branch.

E.g. PR [betka-master-sync] exists for branch `f31`. The new PR for branch `f32` is not created because of Betka checks if [betka-master-sync] exists, even for different branch a do not create as new one.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>