### PR TITLE
Let's use our ucho for Fedora.

### DIFF
--- a/openshift/openshift-fedmsg.yml
+++ b/openshift/openshift-fedmsg.yml
@@ -1,0 +1,31 @@
+---
+  kind: DeploymentConfig
+  apiVersion: v1
+  metadata:
+    labels:
+      service: ucho-fedora-fedmsg
+    name: ucho-fedora-fedmsg
+  spec:
+    template:
+      metadata:
+        labels:
+          name: ucho-fedora-fedmsg
+      spec:
+        containers:
+          - name: ucho-fedora-fedmsg
+            image: docker.io/usercont/ucho
+            env:
+              - name: REDIS_BACKEND
+                value: redis://redis:6379/0
+              - name: REDIS_BROKER
+                value: redis://redis:6379/0
+            resources:
+              requests:
+                memory: "200Mi"
+                cpu: "100m"
+              limits:
+                memory: "400Mi"
+                cpu: "200m"
+    replicas: 1
+    strategy:
+      type: Recreate

--- a/openshift/playbooks/deploy.yml
+++ b/openshift/playbooks/deploy.yml
@@ -45,7 +45,7 @@
         - ../templates/redis.yml
         - ../templates/redis-commander.yml
         - ../templates/flower.yml
-        - ../cloned/ucho/openshift-fedmsg.yml
+        - ../openshift-fedmsg.yml
         - ../serviceaccount.yml
         - ../rolebinding.yml
         - ../pvc.yml


### PR DESCRIPTION
Ucho name will have in OpenSft name ucho-fedora-fedmsg.

The other ucho which is used for internal stuff will have the name ucho-fedmsg.
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>