### PR TITLE
Define new OSCI api by config.json variable

### DIFF
--- a/betka/core.py
+++ b/betka/core.py
@@ -103,6 +103,7 @@ class Betka(Bot):
         self.set_config_from_env(self.config_json["pagure_user"])
         self.set_config_from_env(self.config_json["ocp_project_name"])
         self.betka_config["pagure_api_token"] = os.environ[self.config_json["pagure_api_token"]]
+        self.betka_config["new_api_version"] = bool(self.config_json["new_api_version"] == 'true')
         betka_url_base = self.config_json["betka_url_base"]
         if getenv("DEPLOYMENT") == "prod":
             self.betka_config["betka_yaml_url"] = f"{betka_url_base}betka-prod.yaml"

--- a/betka/pagure.py
+++ b/betka/pagure.py
@@ -137,15 +137,7 @@ class PagureAPI(object):
             namespace=self.config_json["namespace_containers"], repo=self.image
         )
         logger.debug(url_address)
-        (version_major, version_minor) = self.get_api_version()
-        if int(version_major) == 0 and int(version_minor) < 28:
-            data = {
-                "title": title,
-                "branch_to": branch,
-                "branch_from": branch,
-                "initial_comment": desc_msg,
-            }
-        else:
+        if self.betka_config["new_api_version"]:
             data = {
                 "title": title,
                 "branch_to": branch,
@@ -154,6 +146,13 @@ class PagureAPI(object):
                 "repo_from": self.image,
                 "repo_from_namespace": self.config_json["namespace_containers"],
                 "repo_from_username": self.username,
+            }
+        else:
+            data = {
+                "title": title,
+                "branch_to": branch,
+                "branch_from": branch,
+                "initial_comment": desc_msg,
             }
 
         ret_json = self.pagure_post_action(url_address, data=data)
@@ -187,19 +186,6 @@ class PagureAPI(object):
             namespace=self.config_json["namespace_containers"], repo=internal_repo, id=pr_id
         )
         return comment_url
-
-    def get_api_version(self):
-        """
-        Gets the username from token provided by parameter in betka's template.
-        :return: username or None
-        """
-        try:
-            ret_json = self.pagure_post_action(self.config_json["get_version_url"])
-        except KeyError:
-            return None, None
-        if "version" not in ret_json:
-            return None, None
-        return ret_json["version"].split(".")
 
     @property
     def _full_url(self):

--- a/config.json
+++ b/config.json
@@ -7,7 +7,6 @@
   "get_pr_comment" : "https://src.fedoraproject.org/{namespace}/{repo}/pull-request/{id}/comment",
   "get_all_pr" : "https://src.fedoraproject.org/api/0/{namespace}/{repo}/pull-requests",
   "get_user_url" : "https://src.fedoraproject.org/api/0/-/whoami",
-  "get_version_url": "https://src.fedoraproject.org/api/0/-/version",
   "git_url_repo": "https://src.fedoraproject.org/api/0/fork/{user}/{namespace}/{repo}/git/",
   "git_hub_api_4" : "https://api.github.com/graphql",
   "namespace_containers" : "container",
@@ -17,5 +16,6 @@
   "pagure_user" : "PAGURE_USER",
   "ocp_project_name" : "OCP_PROJECT_NAME",
   "betka_url_base" : "https://github.com/sclorg/betka/raw/master/",
-  "readme_url": "https://github/sclorg/betka/blob/master/README.md"
+  "readme_url": "https://github/sclorg/betka/blob/master/README.md",
+  "new_api_version": "true"
 }

--- a/openshift/deployment.yml
+++ b/openshift/deployment.yml
@@ -90,7 +90,7 @@ spec:
           # 'automatic: false' means disable trigger (@ prod)
           # 'automatic: true' means enable trigger (@ stage)
           # This is all you have to change (to true) to enable CD
-          automatic: false
+          automatic: true
           containerNames:
             - betka-fedora
           from:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,23 @@ def config_json():
         "pagure_api_token": "PAGURE_API_TOKEN",
         "ocp_project_name": "dummy_project",
         "betka_url_base": "foobar_url",
+        "new_api_version": "true",
+    }
+
+
+def config_json_api_not_supported():
+    return {
+        "api_url": "https://src.fedoraproject.org/api/0",
+        "get_all_pr": "https://src.fedoraproject.org/api/0/{namespace}/{repo}/pull-requests",
+        "git_url_repo": "https://src.fedoraproject.org/api/0/fork/{user}/{namespace}/{repo}/git/",
+        "get_version_url": "https://src.fedoraproject.org/api/0/-/version",
+        "namespace_containers": "container",
+        "github_api_token": "GITHUB_API_TOKEN",
+        "pagure_user": "PAGURE_USER",
+        "pagure_api_token": "PAGURE_API_TOKEN",
+        "ocp_project_name": "dummy_project",
+        "betka_url_base": "foobar_url",
+        "new_api_version": "false",
     }
 
 

--- a/tests/unit/test_betka_config_json.py
+++ b/tests/unit/test_betka_config_json.py
@@ -40,6 +40,18 @@ def config_json_missing_ocp_project_name():
     }
 
 
+def config_json_missing_new_api_version():
+    return {
+        "api_url": "https://src.fedoraproject.org/api/0",
+        "get_all_pr": "https://src.fedoraproject.org/api/0/{namespace}/{repo}/pull-requests",
+        "git_url_repo": "https://src.fedoraproject.org/api/0/fork/{user}/{namespace}/{repo}/git/",
+        "namespace_containers": "container",
+        "github_api_token": "aklsdjfh19p3845yrp",
+        "pagure_user": "testymctestface",
+        "pagure_api_token": "testing",
+    }
+
+
 def config_json_missing_pagure_api_token():
     return {
         "api_url": "https://src.fedoraproject.org/api/0",
@@ -72,6 +84,7 @@ class TestBetkaCore(object):
             config_json_missing_ocp_project_name(),
             config_json_missing_pagure_api_token(),
             config_json_missing_github_api_token(),
+            config_json_missing_new_api_version(),
         ]
     )
     def test_betka_config_keyerror(self, config_json):

--- a/tests/unit/test_betka_prepare.py
+++ b/tests/unit/test_betka_prepare.py
@@ -27,7 +27,7 @@ import os
 import pytest
 
 from betka.core import Betka
-from tests.conftest import config_json
+from tests.conftest import config_json, config_json_api_not_supported
 
 
 class TestBetkaCore(object):
@@ -91,6 +91,15 @@ class TestBetkaCore(object):
         assert self.betka.betka_config.get("github_api_token") == "aklsdjfh19p3845yrp"
         assert self.betka.betka_config.get("pagure_user") == "testymctestface"
         assert self.betka.betka_config.get("pagure_api_token") == "testing"
+        assert self.betka.betka_config.get("new_api_version")
+
+    def test_new_api_version_not_supported(self):
+        self.betka.config_json = config_json_api_not_supported()
+        self.betka.set_config()
+        assert self.betka.betka_config.get("github_api_token") == "aklsdjfh19p3845yrp"
+        assert self.betka.betka_config.get("pagure_user") == "testymctestface"
+        assert self.betka.betka_config.get("pagure_api_token") == "testing"
+        assert not self.betka.betka_config.get("new_api_version")
 
     def test_wrong_fedmsg_info(self, json_init):
         json_init["topic"] = "org.fedoraproject.prod.github.testing"

--- a/tests/unit/test_pagure.py
+++ b/tests/unit/test_pagure.py
@@ -130,26 +130,3 @@ class TestBetkaPagure(object):
             branch=branch,
             check_user=check_user
         ) == return_code
-
-    @pytest.mark.parametrize(
-        "version_json,major_version,minor_version",
-        [
-            (
-                {"version": "0.28"}, "0", "28",
-            ),
-            (
-                {"version": "0.30"}, "0", "30",
-            ),
-            (
-                {"no_version", "foo"}, None, None,
-            ),
-        ]
-    )
-    def test_api_version(self, version_json, major_version, minor_version):
-        flexmock(self.pa)\
-            .should_receive("pagure_post_action")\
-            .with_args(url="https://src.fedoraproject.org/api/0/-/version")\
-            .and_return(version_json)
-        major, minor = self.pa.get_api_version()
-        assert major == major_version
-        assert minor == minor_version


### PR DESCRIPTION
Let's get rid of detection new_api_version.

The definition is done in config.json file.
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>