### PR TITLE
Fix check bot-cfg in remote dist-git

### DIFF
--- a/betka/git.py
+++ b/betka/git.py
@@ -116,14 +116,11 @@ class Git(FramboGit):
         )
 
     @staticmethod
-    def sync_fork_with_origin(url: str, branch: str):
+    def get_changes_from_distgit(url: str):
         """
         Sync fork with the latest changes from downstream origin.
         * Add downstream origin and upstream
         * fetch upstream
-        * Reset commit with the latest downstream origin
-        * push changes back to origin
-        :param branch: Str: Name of branch to sync
         :param url: Str: URL which is add upstream into origin
         """
         FramboGit.call_git_cmd(f"remote -v")
@@ -136,6 +133,15 @@ class Git(FramboGit):
         if not remote_defined:
             FramboGit.call_git_cmd(f"remote add upstream {url}")
         FramboGit.call_git_cmd(f"fetch upstream")
+
+    @staticmethod
+    def push_changes_into_distgit(branch: str):
+        """
+        Push changes into dist_git branch
+        * Reset commit with the latest downstream origin
+        * push changes back to origin
+        :param branch: Str: Name of branch to sync
+        """
         FramboGit.call_git_cmd(f"reset --hard upstream/{branch}")
         FramboGit.call_git_cmd(f"push origin {branch} --force")
 

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
   "get_pr_comment" : "https://src.fedoraproject.org/{namespace}/{repo}/pull-request/{id}/comment",
   "get_all_pr" : "https://src.fedoraproject.org/api/0/{namespace}/{repo}/pull-requests",
   "get_user_url" : "https://src.fedoraproject.org/api/0/-/whoami",
-  "git_url_repo": "https://src.fedoraproject.org/api/0/fork/{user}/{namespace}/{repo}/git/",
+  "git_url_repo": "https://src.fedoraproject.org/api/0/{fork_user}/{namespace}/{repo}/git/",
   "git_hub_api_4" : "https://api.github.com/graphql",
   "namespace_containers" : "container",
   "pull_request_url" : "ssh://{username}@pkgs.fedoraproject.org",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def config_json():
     return {
         "api_url": "https://src.fedoraproject.org/api/0",
         "get_all_pr": "https://src.fedoraproject.org/api/0/{namespace}/{repo}/pull-requests",
-        "git_url_repo": "https://src.fedoraproject.org/api/0/fork/{user}/{namespace}/{repo}/git/",
+        "git_url_repo": "https://src.fedoraproject.org/api/0/{fork_user}/{namespace}/{repo}/git/",
         "get_version_url": "https://src.fedoraproject.org/api/0/-/version",
         "namespace_containers": "container",
         "github_api_token": "GITHUB_API_TOKEN",
@@ -213,7 +213,7 @@ def one_pullrequest():
                           'status': 'Open',
                           'tags': [],
                           'threshold_reached': None,
-                          'title': 'Update from the upstream https://github.com/sclorg/httpd-container',
+                          'title': '[betka-master-sync]',
                           'uid': '84a79e8ec53c4677b0ed99cfc10bff7f',
                           'updated_on': '1534841326',
                           'user': {'fullname': 'Marek Skalický', 'name': 'foo'}}],

--- a/tests/integration/test_betka_pr_sync.py
+++ b/tests/integration/test_betka_pr_sync.py
@@ -183,6 +183,7 @@ class TestBetkaPrSync(object):
         assert self.betka.betka_config['pagure_user']
         assert self.betka.pagure_api.get_pagure_fork()
         self.betka.clone_url = self.betka.pagure_api.get_clone_url()
+        self.betka.pagure_api.betka_config = self.betka.betka_config
         assert self.betka.clone_url
         self.betka.prepare_downstream_git()
         assert self.betka.downstream_dir


### PR DESCRIPTION
Let's check downstream / remote bot-cfg file instead of fork bot-cfg.yaml file.
Look for the branches from remote instead of from fork.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>