### PR TITLE
Fix traceback in case of gitlab is updated

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dockerfiles: ./Dockerfile
           image: betka
-          tags: latest 1 ${{ github.sha }} 0.7.4
+          tags: latest 1 ${{ github.sha }} 0.7.5
 
       - name: Push betka image to Quay.io
         id: push-to-quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/fedora/fedora:37
 
 ENV NAME=betka-fedora \
-    RELEASE=4 \
+    RELEASE=5 \
     ARCH=x86_64 \
     SUMMARY="Syncs changes from upstream repository to downstream" \
     DESCRIPTION="Syncs changes from upstream repository to downstream" \

--- a/betka/core.py
+++ b/betka/core.py
@@ -338,8 +338,8 @@ class Betka(Bot):
         description_msg = COMMIT_MASTER_MSG.format(
             hash=self.upstream_hash, repo=self.repo
         )
-        mr_id = self.gitlab_api.check_gitlab_merge_requests(branch=branch)
-        if not mr_id:
+        mr = self.gitlab_api.check_gitlab_merge_requests(branch=branch)
+        if not mr:
             Git.get_changes_from_distgit(url=self.gitlab_api.get_forked_ssh_url_to_repo())
             Git.push_changes_to_fork(branch=branch)
 
@@ -362,7 +362,7 @@ class Betka(Bot):
             pr_msg=description_msg,
             upstream_hash=self.upstream_hash,
             branch=branch,
-            mr_id=mr_id,
+            mr=mr,
         )
         self.send_result_email(betka_schema=betka_schema)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_requirements():
 
 setup(
     name="betka",
-    version="0.7.4",
+    version="0.7.5",
     packages=find_packages(exclude=["examples", "tests"]),
     url="https://github.com/sclorg/betka",
     license="GPLv3+",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,6 @@ def two_mrs_both_valid():
         ProjectMRs(3, PROJECT_ID, "rhel-8.6.0", "[betka-master-sync]", "phracek"),
     ]
 
-
 def two_mrs_not_valid():
     return [
         ProjectMRs(


### PR DESCRIPTION
This pull request fixes traceback:

```bash
  File "/usr/local/lib/python3.11/site-packages/celery/app/trace.py", line 477, in trace_task
    R = retval = fun(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/celery/app/trace.py", line 760, in __protected_call__
    return self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/betka/tasks.py", line 33, in master_sync
    betka.run_sync()
  File "/usr/local/lib/python3.11/site-packages/betka/core.py", line 648, in run_sync
    raise ex
  File "/usr/local/lib/python3.11/site-packages/betka/core.py", line 642, in run_sync
    self._run_sync()
  File "/usr/local/lib/python3.11/site-packages/betka/core.py", line 696, in _run_sync
    self._sync_valid_branches(valid_branches)
  File "/usr/local/lib/python3.11/site-packages/betka/core.py", line 633, in _sync_valid_branches
    self.sync_to_downstream_branches(self.downstream_git_branch)
  File "/usr/local/lib/python3.11/site-packages/betka/core.py", line 367, in sync_to_downstream_branches
    self.send_result_email(betka_schema=betka_schema)
  File "/usr/local/lib/python3.11/site-packages/betka/core.py", line 304, in send_result_email
    if not self.slack_notification():
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/betka/core.py", line 282, in slack_notification
    project_mr: ProjectMR = self.betka_schema["merge_request_dict"]
                            ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
```

Test also covers this issue.
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
