### PR TITLE
Use forks only on Request

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dockerfiles: ./Dockerfile
           image: betka
-          tags: latest 1 ${{ github.sha }} 0.8.1
+          tags: latest 1 ${{ github.sha }} 0.9.0
 
       - name: Push betka image to Quay.io
         id: push-to-quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/fedora/fedora:37
 
 ENV NAME=betka-fedora \
-    RELEASE=0.8.1 \
+    RELEASE=0.9.0
     ARCH=x86_64 \
     SUMMARY="Syncs changes from upstream repository to downstream" \
     DESCRIPTION="Syncs changes from upstream repository to downstream" \

--- a/betka/gitlab.py
+++ b/betka/gitlab.py
@@ -305,6 +305,7 @@ class GitLabAPI(object):
         pr_msg: str,
         upstream_hash: str,
         branch: str,
+        origin_branch: str,
         mr: Any,
     ) -> Dict:
         """
@@ -312,6 +313,7 @@ class GitLabAPI(object):
         :param pr_msg: description message used in pull request
         :param upstream_hash: commit hash for
         :param branch: specify downstream branch for file a Pull Request
+        :param origin_branch: specify origin_branch to which file a Pull Request
         :param mr: named touple ProjectMR
         :return: schema for sending email
         """
@@ -323,7 +325,7 @@ class GitLabAPI(object):
             logger.debug(f"Upstream {text_mr} to downstream PR not found.")
 
             mr: ProjectMR = self.create_gitlab_merge_request(
-                title=title, desc_msg=pr_msg, branch=branch
+                title=title, desc_msg=pr_msg, branch=branch, origin_branch=origin_branch
             )
             logger.debug(f"MergeRequest is: {mr}")
             if mr is None:
@@ -375,7 +377,7 @@ class GitLabAPI(object):
         return True
 
     def create_gitlab_merge_request(
-        self, title: str, desc_msg: str, branch: str
+        self, title: str, desc_msg: str, branch: str, origin_branch: str,
     ) -> ProjectMR:
         """
         Creates the pull request for specific image
@@ -392,6 +394,8 @@ class GitLabAPI(object):
             "description": desc_msg,
             "target_project_id": self.project_id,
         }
+        if not self.betka_config["use_gitlab_fork"]:
+            data["target_branch"] = origin_branch
         return self.create_project_mergerequest(data)
 
     def check_gitlab_merge_requests(self, branch: str):
@@ -519,3 +523,4 @@ class GitLabAPI(object):
             raise HTTPError
         self.project_id = ret.json()["id"]
         logger.debug(f"Project id returned from {url} is {self.project_id}")
+        return self.project_id

--- a/config.json
+++ b/config.json
@@ -18,5 +18,6 @@
   "gitlab_host_url": "https://gitlab.com",
   "gitlab_namespace": "redhat/rhel/containers",
   "dist_git_url": "https://src.fedoraproject.org/container",
-  "slack_webhook_url": "SLACK_WEBHOOK_URL"
+  "slack_webhook_url": "SLACK_WEBHOOK_URL",
+  "use_gitlab_forks": "False"
 }

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_requirements():
 
 setup(
     name="betka",
-    version="0.8.1",
+    version="0.9.0",
     packages=find_packages(exclude=["examples", "tests"]),
     url="https://github.com/sclorg/betka",
     license="GPLv3+",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,7 @@ def betka_yaml():
             },
         },
         "downstream_master_msg": "[betka-master-sync]",
+        "use_gitlab_forks": "True"
     }
 
 
@@ -84,6 +85,7 @@ def config_json():
         "gitlab_url_user": "user",
         "dist_git_url": "https://src.fedoraproject.org/containers",
         "slack_webhook_url": "SLACK_WEBHOOK_URL",
+        "use_gitlab_forks": "True",
     }
 
 

--- a/tests/integration/test_betka_upstream_sync.py
+++ b/tests/integration/test_betka_upstream_sync.py
@@ -93,6 +93,7 @@ class TestBetkaMasterSync(object):
         os.environ["GITLAB_API_TOKEN"] = "gitlabsomething"
         os.environ["GITHUB_API_TOKEN"] = "aklsdjfh19p3845yrp"
         os.environ["GITLAB_USER"] = "testymctestface"
+        os.environ["USE_GITLAB_FORKS"] = "true"
         flexmock(FileUtils).should_receive("load_config_json").and_return(config_json())
         self.betka = Betka(task_name="task.betka.master_sync")
         self.config_json = config_json()
@@ -239,6 +240,7 @@ class TestBetkaMasterSync(object):
         mock_rmtree,
     ):
         self.betka.betka_config["dist_git_repos"].pop("s2i-core")
+        self.betka.betka_config["use_gitlab_forks"] = "True"
         list_images = self.betka.get_synced_images()
         sync_image = ""
         for key, value in list_images.items():
@@ -251,6 +253,7 @@ class TestBetkaMasterSync(object):
         flexmock(self.betka).should_receive("_update_valid_remote_branches").and_return(
             ["fc30", "fc31"]
         )
+        flexmock(self.betka).should_receive("prepare_fork_downstream_git").twice()
         # flexmock(Git).should_receive("sync_fork_with_upstream").twice()
         self.betka.gitlab_api.project_id = PROJECT_ID
         flexmock(self.betka.gitlab_api).should_receive("get_project_id_from_url").and_return(PROJECT_ID)

--- a/tests/unit/test_betka_config_json.py
+++ b/tests/unit/test_betka_config_json.py
@@ -64,6 +64,19 @@ def config_json_missing_generator_url():
     }
 
 
+def config_json_missing_use_gitlab_fork():
+    return {
+        "api_url": "https://src.fedoraproject.org/api/0",
+        "get_all_pr": "https://src.fedoraproject.org/api/0/{namespace}/{repo}/pull-requests",
+        "git_url_repo": "https://src.fedoraproject.org/api/0/fork/{user}/{namespace}/{repo}/git/",
+        "namespace_containers": "container",
+        "github_api_token": "aklsdjfh19p3845yrp",
+        "gitlab_user": "testymctestface",
+        "gitlab_api_token": "testing",
+        "generator_url": "some_generator_url",
+    }
+
+
 class TestBetkaCore(object):
     def setup_method(self):
         self.betka = Betka()
@@ -73,6 +86,7 @@ class TestBetkaCore(object):
         [
             config_json_missing_github_api_token(),
             config_json_missing_generator_url(),
+            config_json_missing_use_gitlab_fork(),
         ],
     )
     def test_betka_config_keyerror(self, config_json):

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -86,6 +86,19 @@ class TestBetkaCore(object):
             assert image == image in return_value
 
     @pytest.mark.parametrize(
+        "status,return_value",
+        [
+            ("True", True),
+            ("true", True),
+            ("False", False),
+            ("false", False),
+        ],
+    )
+    def test_is_fork_enabled(self, status, return_value):
+        self.betka.betka_config["use_gitlab_forks"] = status
+        assert self.betka.is_fork_enabled() == return_value
+
+    @pytest.mark.parametrize(
         "msg_upstream_url,return_value",
         [
             (

--- a/tests/unit/test_gitlab.py
+++ b/tests/unit/test_gitlab.py
@@ -186,10 +186,10 @@ class TestBetkaGitlab(object):
             "rhel-8.6.0", "phracek", PROJECT_ID_FORK, PROJECT_ID, "https://gitlab/foo/bar",
         )
         flexmock(self.ga).should_receive("create_gitlab_merge_request").with_args(
-            title="[betka-master-sync]", desc_msg=pr_msg, branch=branch_name
+            title="[betka-master-sync]", desc_msg=pr_msg, branch=branch_name, origin_branch="",
         ).and_return(mr)
         betka_schema = self.ga.file_merge_request(
-            pr_msg=pr_msg, upstream_hash=upstream_hash, branch=branch_name, mr=None
+            pr_msg=pr_msg, upstream_hash=upstream_hash, branch=branch_name, origin_branch="", mr=None
         )
         assert betka_schema
         assert betka_schema["commit"] == upstream_hash
@@ -208,10 +208,10 @@ class TestBetkaGitlab(object):
         upstream_hash = "10938482734"
         flexmock(BetkaEmails).should_receive("send_email").once()
         flexmock(self.ga).should_receive("create_gitlab_merge_request").with_args(
-            title="[betka-master-sync]", desc_msg=pr_msg, branch=branch_name
+            title="[betka-master-sync]", desc_msg=pr_msg, branch=branch_name, origin_branch="",
         ).and_return(mr_id)
         betka_schema = self.ga.file_merge_request(
-            pr_msg=pr_msg, upstream_hash=upstream_hash, branch=branch_name, mr=mr_id
+            pr_msg=pr_msg, upstream_hash=upstream_hash, branch=branch_name, origin_branch="", mr=mr_id
         )
         assert not betka_schema
 
@@ -225,10 +225,10 @@ class TestBetkaGitlab(object):
             PROJECT_ID_FORK, PROJECT_ID, "https://gitlab/foo/bar",
         )
         flexmock(self.ga).should_receive("create_gitlab_merge_request").with_args(
-            title="[betka-master-sync]", desc_msg=pr_msg, branch=branch_name
+            title="[betka-master-sync]", desc_msg=pr_msg, branch=branch_name, origin_branch="",
         ).and_return(mr)
         betka_schema = self.ga.file_merge_request(
-            pr_msg=pr_msg, upstream_hash=upstream_hash, branch=branch_name, mr=mr
+            pr_msg=pr_msg, upstream_hash=upstream_hash, branch=branch_name, origin_branch="", mr=mr
         )
         assert betka_schema
         assert betka_schema["commit"] == upstream_hash


### PR DESCRIPTION
We need to sync source to forks on request.

In case forks are not used then the branch is called 'betka-rhel-9.5.0'
