### PR TITLE
Add missing init_projects when fork is not used.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dockerfiles: ./Dockerfile
           image: betka
-          tags: latest 1 ${{ github.sha }} 0.9.1
+          tags: latest 1 ${{ github.sha }} 0.9.2
 
       - name: Push betka image to Quay.io
         id: push-to-quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/fedora/fedora:37
 
 ENV NAME=betka-fedora \
-    RELEASE=0.9.0 \
+    RELEASE=0.9.2 \
     ARCH=x86_64 \
     SUMMARY="Syncs changes from upstream repository to downstream" \
     DESCRIPTION="Syncs changes from upstream repository to downstream" \

--- a/betka/core.py
+++ b/betka/core.py
@@ -729,6 +729,7 @@ class Betka(Bot):
                     continue
                 branch_list_to_sync = self._update_valid_remote_branches()
             else:
+                self.gitlab_api.init_projects()
                 project_info = self.gitlab_api.get_project_info()
                 self.ssh_url_to_repo = project_info.ssh_url_to_repo
                 self.debug(f"Clone URL is: {self.ssh_url_to_repo}")

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_requirements():
 
 setup(
     name="betka",
-    version="0.9.1",
+    version="0.9.2",
     packages=find_packages(exclude=["examples", "tests"]),
     url="https://github.com/sclorg/betka",
     license="GPLv3+",


### PR DESCRIPTION
Add missing init_projects when fork is not used.

In case init_projects is not used then we have a traceback in real situation

Bump version to 0.9.2.

