### PR TITLE
Fix typo in reading betka_configuration file.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dockerfiles: ./Dockerfile
           image: betka
-          tags: latest 1 ${{ github.sha }} 0.9.5
+          tags: latest 1 ${{ github.sha }} 0.9.6
 
       - name: Push betka image to Quay.io
         id: push-to-quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/fedora/fedora:37
 
 ENV NAME=betka-fedora \
-    RELEASE=0.9.5 \
+    RELEASE=0.9.6 \
     ARCH=x86_64 \
     SUMMARY="Syncs changes from upstream repository to downstream" \
     DESCRIPTION="Syncs changes from upstream repository to downstream" \

--- a/betka/gitlab.py
+++ b/betka/gitlab.py
@@ -394,7 +394,7 @@ class GitLabAPI(object):
             "description": desc_msg,
             "target_project_id": self.project_id,
         }
-        if not self.betka_config["use_gitlab_fork"]:
+        if not self.betka_config["use_gitlab_forks"]:
             data["target_branch"] = origin_branch
         return self.create_project_mergerequest(data)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_requirements():
 
 setup(
     name="betka",
-    version="0.9.5",
+    version="0.9.6",
     packages=find_packages(exclude=["examples", "tests"]),
     url="https://github.com/sclorg/betka",
     license="GPLv3+",


### PR DESCRIPTION
Fix typo in reading betka_configuration file.

'use_gitlab_fork' does not exist.
'use_gitlab_forks' is proper variable.

