### PR TITLE
Fix creating mergerequest from target_project

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dockerfiles: ./Dockerfile
           image: betka
-          tags: latest 1 ${{ github.sha }} 0.9.6
+          tags: latest 1 ${{ github.sha }} 0.9.7
 
       - name: Push betka image to Quay.io
         id: push-to-quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/fedora/fedora:37
 
 ENV NAME=betka-fedora \
-    RELEASE=0.9.6 \
+    RELEASE=0.9.7 \
     ARCH=x86_64 \
     SUMMARY="Syncs changes from upstream repository to downstream" \
     DESCRIPTION="Syncs changes from upstream repository to downstream" \

--- a/betka/gitlab.py
+++ b/betka/gitlab.py
@@ -278,7 +278,10 @@ class GitLabAPI(object):
     def create_project_mergerequest(self, data) -> ProjectMR:
         logger.debug(f"Create mergerequest for project {self.image} with data {data}")
         try:
-            mr = self.source_project.mergerequests.create(data)
+            if self.is_fork_enabled():
+                mr = self.source_project.mergerequests.create(data)
+            else:
+                mr = self.target_project.mergerequests.create(data)
             return ProjectMR(
                 mr.iid,
                 mr.title,
@@ -299,6 +302,12 @@ class GitLabAPI(object):
             if gce.response_code == 409:
                 logger.error("Another MR already exists")
             return None
+
+    def is_fork_enabled(self):
+        value = self.betka_config["use_gitlab_forks"].lower()
+        if value in ["true", "yes"]:
+            return True
+        return False
 
     def file_merge_request(
         self,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_requirements():
 
 setup(
     name="betka",
-    version="0.9.6",
+    version="0.9.7",
     packages=find_packages(exclude=["examples", "tests"]),
     url="https://github.com/sclorg/betka",
     license="GPLv3+",


### PR DESCRIPTION
Use target_project instead of source_project in case forks are not enabled.