### PR TITLE
Fix HTTPError traceback in case of URL is not valid.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dockerfiles: ./Dockerfile
           image: betka
-          tags: latest 1 ${{ github.sha }} 0.10.4
+          tags: latest 1 ${{ github.sha }} 0.10.5
 
       - name: Push betka image to Quay.io
         id: push-to-quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/fedora/fedora:37
 
 ENV NAME=betka-fedora \
-    RELEASE=0.10.4 \
+    RELEASE=0.10.5 \
     ARCH=x86_64 \
     SUMMARY="Syncs changes from upstream repository to downstream" \
     DESCRIPTION="Syncs changes from upstream repository to downstream" \

--- a/betka/core.py
+++ b/betka/core.py
@@ -23,6 +23,8 @@
 import shutil
 import subprocess
 import os
+from urllib.error import HTTPError
+
 import yaml
 import time
 import traceback
@@ -680,7 +682,11 @@ class Betka(Bot):
                     f"checkout -b {self.downstream_git_branch} --track origin/{branch}",
                     msg="Create a new downstream branch"
                 )
-            if not self._get_bot_cfg(branch=branch):
+            try:
+                if not self._get_bot_cfg(branch=branch):
+                    continue
+            except HTTPError as htpe:
+                self.debug(f"HTTPError: It looks like URL is not valid: {htpe}.")
                 continue
 
             # Gets repo url without .git for cloning

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_requirements():
 
 setup(
     name="betka",
-    version="0.10.4",
+    version="0.10.5",
     packages=find_packages(exclude=["examples", "tests"]),
     url="https://github.com/sclorg/betka",
     license="GPLv3+",


### PR DESCRIPTION
Fix HTTPError traceback in case of URL is not valid.

E.g. postresql-13 is not valid for RHEL10.

We do not want to finish with traceback, but continue with operation

OpenShift POD failed, but we want to continue