### PR TITLE
Do not use dist-git at all. Use GitLab directly

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dockerfiles: ./Dockerfile
           image: betka
-          tags: latest 1 ${{ github.sha }} 0.11.2
+          tags: latest 1 ${{ github.sha }} 0.12.0
 
       - name: Push betka image to Quay.io
         id: push-to-quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/fedora/fedora:37
 
 ENV NAME=betka-fedora \
-    RELEASE=0.11.2 \
+    RELEASE=0.12.0 \
     ARCH=x86_64 \
     SUMMARY="Syncs changes from upstream repository to downstream" \
     DESCRIPTION="Syncs changes from upstream repository to downstream" \

--- a/betka/gitlab.py
+++ b/betka/gitlab.py
@@ -492,11 +492,11 @@ class GitLabAPI(object):
             return fork
         return None
 
-    # URL address is: https://gitlab.com/redhat/rhel/containers/nodejs-10/-/raw/rhel-8.6.0/bot-cfg.yml
+    # URL address is:https://gitlab.com/redhat/rhel/containers/mysql-84/-/raw/rhel-9.7.0/bot-cfg.yml?ref_type=heads
     def cfg_url(self, branch, file="bot-cfg.yml"):
         return (
-            f"{self.config_json['dist_git_url']}/"
-            f"{self.image}/plain/{file}?h={branch}"
+            f"{self.config_json['gitlab_web_url']}/{self.config_json['gitlab_namespace']}/"
+            f"{self.image}/-/raw/{branch}/{file}?ref_type=heads"
         )
 
     def get_bot_cfg_yaml(self, branch: str) -> Dict:
@@ -522,7 +522,7 @@ class GitLabAPI(object):
             "Content-Type": "application/json",
             "PRIVATE-TOKEN": self.betka_config["gitlab_api_token"].strip()
         }
-        url_namespace = f"redhat/rhel/containers/{self.image}"
+        url_namespace = f"{self.config_json['gitlab_namespace']}/{self.image}"
         url = f"{url}/{url_namespace.replace('/', '%2F')}"
         logger.debug(f"Get project_id from {url}")
         ret = requests.get(url=f"{url}", headers=headers, verify=False)

--- a/config.json
+++ b/config.json
@@ -14,7 +14,6 @@
   "gitlab_create_merge_request": "projects/{id}/merge_requests",
   "gitlab_host_url": "https://gitlab.com",
   "gitlab_namespace": "redhat/rhel/containers",
-  "dist_git_url": "https://src.fedoraproject.org/container",
   "slack_webhook_url": "SLACK_WEBHOOK_URL",
   "use_gitlab_forks": "False"
 }

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_requirements():
 
 setup(
     name="betka",
-    version="0.11.2",
+    version="0.12.0",
     packages=find_packages(exclude=["examples", "tests"]),
     url="https://github.com/sclorg/betka",
     license="GPLv3+",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,6 @@ def config_json():
         "gitlab_create_merge_request": "projects/{id}/merge_requests",
         "gitlab_host_url": "https://gitlab.com/",
         "gitlab_url_user": "user",
-        "dist_git_url": "https://src.fedoraproject.org/containers",
         "slack_webhook_url": "SLACK_WEBHOOK_URL",
         "use_gitlab_forks": "True",
     }

--- a/tests/unit/test_gitlab.py
+++ b/tests/unit/test_gitlab.py
@@ -120,37 +120,38 @@ class TestBetkaGitlab(object):
         assert mr.iid == 2
         assert mr.target_branch == "rhel-8.6.0"
 
+#     # URL address is:https://gitlab.com/redhat/rhel/containers/mysql-84/-/raw/rhel-9.7.0/bot-cfg.yml?ref_type=heads
     @pytest.mark.parametrize(
         "host,namespace,image,branch,file,result_url",
         [
             (
-                "https://src.fedoraproject.org/containers",
+                "https://gitlab.com",
                 "containers",
                 "postgresql",
                 "",
                 "bot-cfg.yml",
-                "https://src.fedoraproject.org/containers/postgresql/plain/bot-cfg.yml?h=",
+                "https://gitlab.com/containers/postgresql/-/raw//bot-cfg.yml?ref_type=heads",
             ),
             (
-                "https://src.fedoraproject.org/containers",
+                "https://gitlab.com",
                 "containers",
                 "postgresql",
                 "master",
                 "foo-bar.yaml",
-                "https://src.fedoraproject.org/containers/postgresql/plain/foo-bar.yaml?h=master",
+                "https://gitlab.com/containers/postgresql/-/raw/master/foo-bar.yaml?ref_type=heads",
             ),
             (
-                "https://src.fedoraproject.org/containers",
-                "containers",
+                "https://gitlab.com",
+                "fedora/containers",
                 "dummy-container",
                 "f36",
                 "foo-bar.yaml",
-                "https://src.fedoraproject.org/containers/dummy-container/plain/foo-bar.yaml?h=f36",
+                "https://gitlab.com/fedora/containers/dummy-container/-/raw/f36/foo-bar.yaml?ref_type=heads",
             ),
         ],
     )
     def test_cfg_url(self, host, namespace, image, branch, file, result_url):
-        self.ga.config_json["dist_git_url"] = host
+        self.ga.config_json["gitlab_web_url"] = host
         self.ga.config_json["gitlab_namespace"] = namespace
         self.ga.image = image
         assert result_url == self.ga.cfg_url(branch=branch, file=file)


### PR DESCRIPTION
This pull request disables using internal dist-git repository and use rather directly GitLab from specific branch as main target.
