### PR TITLE
Support definition multiple branches for each component. Global remains.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dockerfiles: ./Dockerfile
           image: betka
-          tags: latest 1 ${{ github.sha }} 0.12.7
+          tags: latest 1 ${{ github.sha }} 0.13.0
 
       - name: Push betka image to Quay.io
         id: push-to-quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/fedora/fedora:39
 
 ENV NAME=betka-fedora \
-    RELEASE=0.12.7 \
+    RELEASE=0.13.0 \
     ARCH=x86_64 \
     SUMMARY="Syncs changes from upstream repository to downstream" \
     DESCRIPTION="Syncs changes from upstream repository to downstream" \

--- a/betka-prod.yaml
+++ b/betka-prod.yaml
@@ -10,7 +10,7 @@ synchronize_branches: ["f34", "f35"]
 dist_git_repos:
   s2i-base:
     url: https://github.com/sclorg/s2i-base-container
-    branches: ["f40", "f41"]
+    synchronize_branches: ["f40", "f41"]
   s2i-core:
     url: https://github.com/sclorg/s2i-base-container
   python3:

--- a/betka/git.py
+++ b/betka/git.py
@@ -28,7 +28,7 @@ from subprocess import CalledProcessError
 from typing import Dict, List
 
 from betka.utils import run_cmd
-from betka.constants import SYNCHRONIZE_BRANCHES, DOWNSTREAM_CONFIG_FILE
+from betka.constants import DOWNSTREAM_CONFIG_FILE
 
 logger = getLogger(__name__)
 
@@ -230,15 +230,14 @@ class Git(object):
 
     @staticmethod
     def branches_to_synchronize(
-        betka_config: Dict, all_branches: List[str]
+        branches_to_sync: List[str], all_branches: List[str]
     ) -> List[str]:
         """
         Checks if branch mentioned in betka configuration file
         is mentioned in valid_branches
         :return: list of valid branches to sync
         """
-        synchronize_branches = tuple(betka_config.get(SYNCHRONIZE_BRANCHES, []))
-        return [b for b in all_branches if b in synchronize_branches]
+        return [b for b in all_branches if b in branches_to_sync]
 
     @staticmethod
     def call_git_cmd(

--- a/betka/gitlab.py
+++ b/betka/gitlab.py
@@ -346,8 +346,7 @@ class GitLabAPI(object):
                 )
                 return betka_schema
             betka_schema["status"] = "created"
-            mr_id = int(mr.iid)
-            betka_schema["merge_request_dict"] = mr
+            betka_schema["merge_request_dict"] = int(mr.iid)
             betka_schema["image"] = self.image
 
         else:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_requirements():
 
 setup(
     name="betka",
-    version="0.12.7",
+    version="0.13.0",
     packages=find_packages(exclude=["examples", "tests"]),
     url="https://github.com/sclorg/betka",
     license="GPLv3+",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,31 @@ def betka_yaml():
         "use_gitlab_forks": "True"
     }
 
+def betka_yaml_specific_branches():
+    return {
+        "synchronize_branches": ["fc3"],
+        "dist_git_repos": {
+            "s2i-core": {
+                "url": "https://github.com/sclorg/s2i-base-container",
+                "synchronize_branches": ["f40", "f41"]
+            },
+            "s2i-base": {
+                "url": "https://github.com/sclorg/s2i-base-container",
+            },
+            "postgresql": {
+                "url": "https://github.com/sclorg/postgresql-container",
+            },
+            "nodejs-10": {
+                "url": "https://github.com/sclorg/s2i-nodejs-container",
+            },
+            "nginx-container": {
+                "url": "https://github.com/sclorg/nginx-container",
+            },
+        },
+        "downstream_master_msg": "[betka-master-sync]",
+        "use_gitlab_forks": "True"
+    }
+
 
 def config_json():
     return {

--- a/tests/integration/test_betka_upstream_sync.py
+++ b/tests/integration/test_betka_upstream_sync.py
@@ -233,7 +233,8 @@ class TestBetkaMasterSync(object):
     def test_betka_push_changes_devel_mode(self):
         self.betka.betka_config["devel_mode"] = "true"
         flexmock(BetkaEmails).should_receive("send_email").once()
-        assert self.betka.update_gitlab_merge_request(mr=None, branch="fc40", origin_branch="") is False
+        self.betka.existing_mr = None
+        assert self.betka.update_gitlab_merge_request(branch="fc40", origin_branch="") is False
 
     def test_betka_run_master_sync(
         self,

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -117,8 +117,8 @@ class TestGit(object):
         ],
     )
     def test_branches_to_synchronize(self, all_branches, expected_result):
-        betka_config = {"synchronize_branches": ["rhscl38", "rhel7", "rhel-8.8"]}
-        result_list = Git.branches_to_synchronize(betka_config=betka_config, all_branches=all_branches)
+        branches_to_sync = ["rhscl38", "rhel7", "rhel-8.8"]
+        result_list = Git.branches_to_synchronize(branches_to_sync=branches_to_sync, all_branches=all_branches)
         assert result_list == expected_result
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Support several multiple synchronize branches
for each components if exist.

Examples:
synchronize_branches: ["f34", "f35"]

dist_git_repos:
  s2i-base:
    url: https://github.com/sclorg/s2i-base-container
    synchronize_branches: ["f40", "f41"]

